### PR TITLE
DOTNETバージョンを9.0.xから8.0.xにダウングレード

### DIFF
--- a/.github/workflows/webapp-deploy.yml
+++ b/.github/workflows/webapp-deploy.yml
@@ -18,7 +18,7 @@ permissions:
   id-token: write
 
 env:
-  DOTNET_VERSION: '9.0.x'
+  DOTNET_VERSION: '8.0.x'
   WEBAPP_NAME: 'qinforanker'
   WEBAPP_PACKAGE_PATH: './publish'
 


### PR DESCRIPTION
webapp-deploy.yml内のDOTNET_VERSIONを9.0.xから8.0.xに変更し、.NET 8でのビルド・デプロイに対応しました。